### PR TITLE
Update target.txt with other common checkers

### DIFF
--- a/module/target.txt
+++ b/module/target.txt
@@ -1,6 +1,7 @@
-com.google.android.gsf
-com.google.android.gms
 com.android.vending
+com.google.android.gms
 io.github.vvb2060.keyattestation
 io.github.vvb2060.mahoshojo
 icu.nullptr.nativetest
+com.reveny.nativecheck
+com.zhenxi.hunter


### PR DESCRIPTION
Tidy up again to reorder/organize slightly, matching official, then add a few more common checkers.

Note: gsf has never been needed, just gms and vending, that's why it's not in official.