### PR TITLE
Honour StrongBox security level when requested in generate mode

### DIFF
--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/interceptors/SecurityLevelInterceptor.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/interceptors/SecurityLevelInterceptor.kt
@@ -82,7 +82,7 @@ class SecurityLevelInterceptor(
                 val entropy = data.createByteArray()
                 val kgp = CertificateHacker.KeyGenParameters(params)
                 if (Config.needGenerate(callingUid)) {
-                    val pair = CertificateHacker.generateKeyPair(callingUid, keyDescriptor, attestationKeyDescriptor, kgp)
+                    val pair = CertificateHacker.generateKeyPair(callingUid, keyDescriptor, attestationKeyDescriptor, kgp, level)
                         ?: return@runCatching
                     keyPairs[Key(callingUid, keyDescriptor.alias)] = Pair(pair.first, pair.second)
                     val response = buildResponse(pair.second, kgp, attestationKeyDescriptor ?: keyDescriptor)
@@ -94,7 +94,7 @@ class SecurityLevelInterceptor(
                 } else if (Config.needHack(callingUid)) {
                     if ((kgp.purpose.contains(7)) || (attestationKeyDescriptor != null)) {
                         Logger.i("Generating key in generation mode for attestation: uid=$callingUid alias=${keyDescriptor.alias}")
-                        val pair = CertificateHacker.generateKeyPair(callingUid, keyDescriptor, attestationKeyDescriptor, kgp)
+                        val pair = CertificateHacker.generateKeyPair(callingUid, keyDescriptor, attestationKeyDescriptor, kgp, level)
                             ?: return@runCatching
                         keyPairs[Key(callingUid, keyDescriptor.alias)] = Pair(pair.first, pair.second)
                         val response = buildResponse(pair.second, kgp, attestationKeyDescriptor ?: keyDescriptor)


### PR DESCRIPTION
This change causes the interceptor to return certificates with the StrongBox (enum 2) attestation and key[mint/master] security level fields when requested by the calling package. This brings the behaviour in line with the proprietary module.

Before this change, the values are hardcoded for the TEE security level (enum 1) when generate mode is used with a package, regardless of whether a StrongBox-backed certificate was requested. With the change, the module defaults to the TEE security level unless the generate call comes from the `SecurityLevelInterceptor` instance registered for the StrongBox security level.

I don't expect this to affect PI attestations but it may help with other apps that request/expect StrongBox-backed attestation certificates using [`setIsStrongBoxBacked(true)`](https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder#setIsStrongBoxBacked(boolean)).

Please let me know if you think there's a better way to implement this but I reckon defaulting to the existing behaviour (TEE security level) is the safest approach.

## Demonstration

Before change (build 47 2357bd2) (Left: `Use StrongBox` unchecked. Right: checked):
<img width="270" alt="Screenshot_20250814-195527_Key Attestation" src="https://github.com/user-attachments/assets/28e6dc65-e130-4ce1-8c9a-b81388d9d5e4" />&nbsp;<img width="270" alt="Screenshot_20250814-195543_Key Attestation" src="https://github.com/user-attachments/assets/52cfb3f6-0b1e-4a52-953f-efa8d2d56e12" />

After change (Left: `Use StrongBox` unchecked. Right: checked):
<img width="270" alt="Screenshot_20250814-195056_Key Attestation" src="https://github.com/user-attachments/assets/dbf139ac-f976-47d5-807d-fff61111302d" />&nbsp;<img width="270" alt="Screenshot_20250814-195041_Key Attestation" src="https://github.com/user-attachments/assets/83ae15f1-51ac-41c5-9d89-c98dba8042ae" />


## Context

I have been looking through and comparing some of the changes I made to my local copy of the [last open source commit](https://github.com/5ec1cff/TrickyStore/tree/master) of the original module. The only addition I could find that you haven't already implemented/exceeded with this fork is the behaviour described above. Thanks for your work on developing the codebase to match the proprietary version and maintaining the open source nature of an important Android community project! :heart: