### PR TITLE
Fix failed to get packages

### DIFF
--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/core/config/Config.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/core/config/Config.kt
@@ -7,6 +7,7 @@ package io.github.beakthoven.TrickyStoreOSS.core.config
 
 import android.content.pm.IPackageManager
 import android.os.FileObserver
+import android.os.IInterface
 import android.os.ServiceManager
 import io.github.beakthoven.TrickyStoreOSS.CertificateHacker
 import io.github.beakthoven.TrickyStoreOSS.core.logging.Logger
@@ -128,7 +129,7 @@ object Config {
     private var iPm: IPackageManager? = null
 
     fun getPm(): IPackageManager? {
-        if (iPm == null) {
+        if (iPm == null || (iPm as? IInterface)?.asBinder()?.pingBinder() != true) {
             iPm = IPackageManager.Stub.asInterface(ServiceManager.getService("package"))
         }
         return iPm


### PR DESCRIPTION
On some devices the IPackageManager binder is no longer valid after startup and throws an exception.
The following changes make sure the binder is always valid before calling the IPackageManager interface.

```
E TrickyStoreOSS: wtf: failed to get packages
E TrickyStoreOSS: android.os.DeadObjectException
E TrickyStoreOSS: 	at android.os.BinderProxy.transactNative(Native Method)
E TrickyStoreOSS: 	at android.os.BinderProxy.transact(BinderProxy.java:592)
E TrickyStoreOSS: 	at android.content.pm.IPackageManager$Stub$Proxy.getPackagesForUid(IPackageManager.java:5122)
E TrickyStoreOSS: 	at io.github.beakthoven.TrickyStoreOSS.core.config.Config.needGenerate(Config.kt:154)
E TrickyStoreOSS: 	at io.github.beakthoven.TrickyStoreOSS.interceptors.Keystore2Interceptor.onPreTransact(Keystore2Interceptor.kt:82)
E TrickyStoreOSS: 	at io.github.beakthoven.TrickyStoreOSS.interceptors.BinderInterceptor.handlePreTransact(BinderInterceptor.kt:125)
E TrickyStoreOSS: 	at io.github.beakthoven.TrickyStoreOSS.interceptors.BinderInterceptor.onTransact(BinderInterceptor.kt:104)
E TrickyStoreOSS: 	at android.os.Binder.execTransactInternal(Binder.java:1426)
E TrickyStoreOSS: 	at android.os.Binder.execTransact(Binder.java:1365)
E TrickyStoreOSS: wtf: failed to get packages
E TrickyStoreOSS: android.os.DeadObjectException
E TrickyStoreOSS: 	at android.os.BinderProxy.transactNative(Native Method)
E TrickyStoreOSS: 	at android.os.BinderProxy.transact(BinderProxy.java:592)
E TrickyStoreOSS: 	at android.content.pm.IPackageManager$Stub$Proxy.getPackagesForUid(IPackageManager.java:5122)
E TrickyStoreOSS: 	at io.github.beakthoven.TrickyStoreOSS.core.config.Config.needHack(Config.kt:139)
E TrickyStoreOSS: 	at io.github.beakthoven.TrickyStoreOSS.interceptors.Keystore2Interceptor.onPreTransact(Keystore2Interceptor.kt:87)
E TrickyStoreOSS: 	at io.github.beakthoven.TrickyStoreOSS.interceptors.BinderInterceptor.handlePreTransact(BinderInterceptor.kt:125)
E TrickyStoreOSS: 	at io.github.beakthoven.TrickyStoreOSS.interceptors.BinderInterceptor.onTransact(BinderInterceptor.kt:104)
E TrickyStoreOSS: 	at android.os.Binder.execTransactInternal(Binder.java:1426)
E TrickyStoreOSS: 	at android.os.Binder.execTransact(Binder.java:1365)
```