### PR TITLE
Handle ECDSA algorithm alternate name from parseKeyPair

### DIFF
--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/KeyBoxUtils.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/KeyBoxUtils.kt
@@ -90,6 +90,7 @@ object KeyBoxUtils {
             val derived = keyPair.private.algorithm
             val algorithmName =
                 when (derived.uppercase()) {
+                    "ECDSA" -> KeyProperties.KEY_ALGORITHM_EC
                     KeyProperties.KEY_ALGORITHM_EC -> KeyProperties.KEY_ALGORITHM_EC
                     KeyProperties.KEY_ALGORITHM_RSA -> KeyProperties.KEY_ALGORITHM_RSA
                     else -> derived


### PR DESCRIPTION
After observing the behaviour where the RSA chain is selected despite requesting an ECDSA cert, I added some logging lines to follow the algorithm naming from the XML keybox parsing in _KeyBoxUtils.kt_.

This revealed that `CertificateUtils.parseKeyPair()` returns _ECDSA_ in some cases, not _EC_.

This change therefore adds a `when` clause to cover this possibility.

After building locally with Android Studio and testing on devices running LineageOS 22.2/A15 and 23.2/A16, I'm now seeing the correct chains when RSA is toggled on/off in Key Attestation Demo.

Closes #78